### PR TITLE
Establish using the hardware watchdog

### DIFF
--- a/watchdog-simple.service
+++ b/watchdog-simple.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run shell script that opens watchdog and regularly writes to it
+
+[Service]
+Type=exec
+ExecStart=/usr/local/sbin/watchdog-simple.sh
+Restart=on-success
+
+[Install]
+WantedBy=multi-user.target

--- a/watchdog-simple.sh
+++ b/watchdog-simple.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+{
+  while true;do
+     echo "x"
+  done
+} > /dev/watchdog


### PR DESCRIPTION
A script that is expected to keep running as long as the userspace is working in any way. Stopping the script will result in a hardware reset of the device.